### PR TITLE
Implemented socket game rooms

### DIFF
--- a/tic-tac-dope-client/server.ts
+++ b/tic-tac-dope-client/server.ts
@@ -51,8 +51,13 @@ app.get("/game/:id", async (req, res) => {
 
 io.on('connection', (socket) => {
   console.log('a user connected')
-  socket.on('move', (message) => {
-    console.log('move: ', message)
+  socket.on('join-game', (gameId) => {
+    console.log(`game ${gameId} was joined`)
+    socket.join(gameId)
+  })
+  socket.on('leave-game', (gameId) => {
+    console.log(`game ${gameId} was left`)
+    socket.leave(gameId)
   })
 })
 
@@ -66,7 +71,9 @@ app.post("/move/:id", async (req, res) => {
   })
   .where(eq(gamesTable.id, req.params.id))
   .returning()
-  io.emit('move', updatedGame[0])
+  io.to(req.params.id).emit('move', updatedGame[0], () => {
+    console.log(`move emitted to ${req.params.id}`)
+  })
   console.log('move emitted!')
   res.json(updatedGame[0])
 })

--- a/tic-tac-dope-client/src/components/Game.tsx
+++ b/tic-tac-dope-client/src/components/Game.tsx
@@ -26,19 +26,24 @@ function Game(props: GameProps) {
 
   const queryClient = useQueryClient()
   useEffect(() => {
+    socket.emit('join-game', props.id)
+
     socket.on('move', (gameState) => {
       console.log('move received')
-      return queryClient.setQueryData(['gameState'], gameState)
+      // this is a terrible hack, have to find a way to make sure emit sockets are opened
+      // and attached to a specific game
+        return queryClient.setQueryData(['gameState', props.id], gameState)
     })
 
     return () => {
+      socket.emit('leave-game', props.id)
       socket.off('move')
     }
   }, [queryClient, props.id])
 
   // why is this being called multiple times?
   const query = useQuery({
-    queryKey: ["gameState"],
+    queryKey: ["gameState", props.id],
     queryFn: () => axios.get(`/game/${props.id}`).then((res) => res.data)
   })
 


### PR DESCRIPTION
Found a bug, where if a user made a move in a different game, it would overwrite ALL GAMES BEING PLAYED. That is not ideal! Fixed this by implementing socket rooms so that moves are emitted to specific sockets attached to each game.